### PR TITLE
Fix install SQL statement

### DIFF
--- a/includes/class-mailchimp-woocommerce-activator.php
+++ b/includes/class-mailchimp-woocommerce-activator.php
@@ -117,7 +117,7 @@ class MailChimp_Woocommerce_Activator {
 		$sql = "CREATE TABLE IF NOT EXISTS {$wpdb->prefix}mailchimp_carts (
 				id VARCHAR (255) NOT NULL,
 				email VARCHAR (100) NOT NULL,
-				user_id INT (11) NULLABLE,
+				user_id INT (11) NULL,
                 cart text NOT NULL,
                 created_at datetime NOT NULL
 				) $charset_collate;";


### PR DESCRIPTION
The initial CREATE TABLE statement uses a non-compliant SQL statement. This causes the plugin to fail to install properly for any new user installs.