### PR TITLE
Use of mailchimp_get_store_id()

### DIFF
--- a/includes/class-mailchimp-woocommerce-options.php
+++ b/includes/class-mailchimp-woocommerce-options.php
@@ -63,7 +63,7 @@ abstract class MailChimp_Woocommerce_Options
      */
     public function getUniqueStoreID()
     {
-        return md5(get_option('siteurl'));
+        return mailchimp_get_store_id();
     }
 
     /**

--- a/includes/processes/class-mailchimp-woocommerce-abstract-sync.php
+++ b/includes/processes/class-mailchimp-woocommerce-abstract-sync.php
@@ -59,7 +59,7 @@ abstract class MailChimp_WooCommerce_Abtstract_Sync extends WP_Job
      */
     public function getStoreID()
     {
-        return md5(get_option('siteurl'));
+        return mailchimp_get_store_id();
     }
 
     /**

--- a/mailchimp-woocommerce.php
+++ b/mailchimp-woocommerce.php
@@ -60,7 +60,7 @@ function mailchimp_get_list_id() {
  * @return string
  */
 function mailchimp_get_store_id() {
-	return md5(get_option('siteurl'));
+	return apply_filters('mailchimp-woocommerce-store-id', md5(get_option('siteurl')));
 }
 
 /**

--- a/mailchimp-woocommerce.php
+++ b/mailchimp-woocommerce.php
@@ -60,7 +60,15 @@ function mailchimp_get_list_id() {
  * @return string
  */
 function mailchimp_get_store_id() {
-	return apply_filters('mailchimp-woocommerce-store-id', md5(get_option('siteurl')));
+	$store_id = get_option('mailchimp-woocommerce-store-id', false);
+
+	if (!$store_id) {
+		$store_id = apply_filters('mailchimp-woocommerce-store-id', md5(get_option('siteurl')));
+
+		update_option('mailchimp-woocommerce-store-id', $store_id);
+	}
+
+	return $store_id;
 }
 
 /**


### PR DESCRIPTION
 * Leave only one source of store ID generation.
 * Hold store ID as an option in database
 * Allow filters hooking into the store ID