### PR TITLE
Add copy for Facebook Ads feature

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,7 @@ You’ll have the power to:
 - Send product recommendations
 - Segment based on purchase history
 - View your results and measure ROI
+- Grow your audience and sell more stuff with Facebook Ad Campaigns in MailChimp
 
 ###A note for current WooCommerce integration users
 This plugin supports our most powerful API 3.0 features, and is intended for users who have not yet integrated their WooCommerce stores with MailChimp.


### PR DESCRIPTION
The `README.txt` in this repo is currently out-of-sync with the `README.txt` in the WP plugin directory, as it's missing some copy that marketing added.

This adds the missing line.