### PR TITLE
Load admin scripts only on MailChimp admin screen.

### DIFF
--- a/admin/class-mailchimp-woocommerce-admin.php
+++ b/admin/class-mailchimp-woocommerce-admin.php
@@ -147,6 +147,8 @@ class MailChimp_Woocommerce_Admin extends MailChimp_Woocommerce_Options {
 	 * @since    1.0.0
 	 */
 	public function display_plugin_setup_page() {
+		$this->enqueue_scripts();
+		$this->enqueue_styles();
 		include_once( 'partials/mailchimp-woocommerce-admin-tabs.php' );
 	}
 

--- a/includes/class-mailchimp-woocommerce.php
+++ b/includes/class-mailchimp-woocommerce.php
@@ -242,9 +242,6 @@ class MailChimp_Woocommerce {
 
 		$plugin_admin = new MailChimp_Woocommerce_Admin( $this->get_plugin_name(), $this->get_version() );
 
-		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');
-		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts');
-
 		// Add menu item
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_plugin_admin_menu');
 


### PR DESCRIPTION
Currently the admin scripts and styles used for MailChimp are being loaded on every page in the WordPress dashboard. This update makes it so they only load on the actual MailChimp admin screen.