### PR TITLE
Update shipping address name on orders

### DIFF
--- a/includes/api/class-mailchimp-woocommerce-transform-orders-wc3.php
+++ b/includes/api/class-mailchimp-woocommerce-transform-orders-wc3.php
@@ -265,13 +265,7 @@ class MailChimp_WooCommerce_Transform_Orders
         // shipping does not have a phone number, so maybe use this?
         $address->setPhone($order->get_billing_phone());
 
-        $sfn = $order->get_billing_first_name();
-        $sln = $order->get_billing_last_name();
-
-        // if we have billing names set it here
-        if (!empty($sfn) && !empty($sln)) {
-            $address->setName("{$sfn} {$sln}");
-        }
+        $address->setName($order->get_shipping_first_name().' '.$order->get_shipping_last_name());
 
         return $address;
     }


### PR DESCRIPTION
Shipping address name should be used instead of only the billing address name.

Closes https://github.com/mailchimp/mc-woocommerce/issues/162