### PR TITLE
updated newsletter checkbox to be consistent w/woocommerce classes/styles

### DIFF
--- a/includes/class-mailchimp-woocommerce-newsletter.php
+++ b/includes/class-mailchimp-woocommerce-newsletter.php
@@ -41,9 +41,12 @@ class MailChimp_Newsletter extends MailChimp_Woocommerce_Options
 
             // echo out the checkbox.
             $checkbox = '<p class="form-row form-row-wide create-account">';
-            $checkbox .= '<input class="input-checkbox" id="mailchimp_woocommerce_newsletter" type="checkbox" ';
-            $checkbox .= 'name="mailchimp_woocommerce_newsletter" value="1"'.($status ? ' checked="checked"' : '').'>';
-            $checkbox .= '<label for="mailchimp_woocommerce_newsletter" class="checkbox">'.$label.'</label></p>';
+            $checkbox .= '<label for="mailchimp_woocommerce_newsletter" class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox">';
+            $checkbox .= '<input class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" id="mailchimp_woocommerce_newsletter" type="checkbox" ';
+            $checkbox .= 'name="mailchimp_woocommerce_newsletter" value="1"'.($status ? ' checked="checked"' : '').'> ';
+            $checkbox .= '<span>' . $label . '</span>';
+            $checkbox .= '</label>';
+            $checkbox .= '</p>';
             $checkbox .= '<div class="clear"></div>';
 
             echo $checkbox;


### PR DESCRIPTION
I updated the HTML for the newsletter subscribe checkbox to be a consistent with other WooCommerce checkboxes, specifically the "Create an account?" checkbox that appears directly below the Mailchimp checkbox. Previously, the spacing was inconsistent and I thought it looked sloppy.