### PR TITLE
Allow custom field mapping

### DIFF
--- a/includes/processes/class-mailchimp-woocommerce-user-submit.php
+++ b/includes/processes/class-mailchimp-woocommerce-user-submit.php
@@ -99,6 +99,8 @@ class MailChimp_WooCommerce_User_Submit extends WP_Job
 
         if (!empty($fn)) $merge_vars['FNAME'] = $fn;
         if (!empty($ln)) $merge_vars['LNAME'] = $ln;
+        
+        $merge_vars = apply_filters( 'mailchimp_sync_user_mergetags', $user, $merge_vars );
 
         try {
 


### PR DESCRIPTION
Using Mailchimp "merge tags", this filter allows to pass a array of merge tags to each user submitted to Mailchimp.

Issue Reference: #145  

```php
/**
* Example with "COUNTRY" custom merge tag 
*
* @param WP_User $user
* @param array $merge_tags
*
* @return array
*/
function custom_mailchimp_sync_user_mergetags($user, $merge_tags){
  $billing_country = get_user_meta($user->ID, 'billing_country', true);
  if( !empty($billing_country) ){
    $merge_tags['COUNTRY'] = $billing_country;
  }
  return $merge_tags;
}
add_filter( 'mailchimp_sync_user_mergetags', 'custom_mailchimp_sync_user_mergetags', 100, 2);
```