### PR TITLE
Abandond Cart not working for Logged-In Users - Issue 238

### DIFF
--- a/includes/class-mailchimp-woocommerce.php
+++ b/includes/class-mailchimp-woocommerce.php
@@ -319,7 +319,9 @@ class MailChimp_WooCommerce {
 			// when someone deletes a user??
 			//$this->loader->add_action('delete_user', $service, 'handleUserDeleting');
 
+			$this->loader->add_action('wp_ajax_mailchimp_get_user_by_hash', $service, 'get_user_by_hash');
 			$this->loader->add_action('wp_ajax_nopriv_mailchimp_get_user_by_hash', $service, 'get_user_by_hash');
+			$this->loader->add_action('wp_ajax_mailchimp_set_user_by_email', $service, 'set_user_by_email');
 			$this->loader->add_action('wp_ajax_nopriv_mailchimp_set_user_by_email', $service, 'set_user_by_email');
 		}
 	}


### PR DESCRIPTION
Added additional Ajax action calls for wp_ajax_{$_REQUEST['action']} for authenticated Ajax actions for logged-in users and resolve admin-ajax.php 400 unsafe URL error.

https://github.com/mailchimp/mc-woocommerce/issues/238