### PR TITLE
Fix issue with multisite admin not loading intermittently

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -328,6 +328,10 @@ function mailchimp_check_woocommerce_plugin_status()
     if (in_array('woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option('active_plugins')))) {
         return true;
     }
+    // Load this function if not registered, doesn't mean we're not on a multisite..
+    if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+        require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
+    }
     // lets check for network activation woo installs now too.
     if (function_exists('is_plugin_active_for_network')) {
         return is_plugin_active_for_network( 'woocommerce/woocommerce.php');


### PR DESCRIPTION
Fixes #274 

It's great to check if the function exists before calling it (defensive coding, woo) but just because the function isn't registered it does not indicate that we are not within a multisite environment.

I've tested this patch locally and it's restored the admin UI across the sub sites, there are no tests etc but it shouldn't be necessary for this change.