### PR TITLE
Feat/2.1.16/html in optin :: allow HTML in opt-in checkbox

### DIFF
--- a/admin/class-mailchimp-woocommerce-admin.php
+++ b/admin/class-mailchimp-woocommerce-admin.php
@@ -492,9 +492,18 @@ class MailChimp_WooCommerce_Admin extends MailChimp_WooCommerce_Options {
 			$checkbox = $input['mailchimp_checkbox_defaults'];
 		}
 
+		$allowed_html = array(
+			'a' => array(
+				'href' => array(),
+				'title' => array(),
+				'target' => array()
+			),
+			'br' => array()
+		);
+
 		$data = array(
 			'mailchimp_list' => isset($input['mailchimp_list']) ? $input['mailchimp_list'] : $this->getOption('mailchimp_list', ''),
-			'newsletter_label' => isset($input['newsletter_label']) ? $input['newsletter_label'] : $this->getOption('newsletter_label', __('Subscribe to our newsletter', 'mailchimp-woocommerce')),
+			'newsletter_label' => isset($input['newsletter_label']) ? wp_kses($input['newsletter_label'], $allowed_html) : $this->getOption('newsletter_label', __('Subscribe to our newsletter', 'mailchimp-woocommerce')),
 			'mailchimp_auto_subscribe' => isset($input['mailchimp_auto_subscribe']) ? (bool) $input['mailchimp_auto_subscribe'] : $this->getOption('mailchimp_auto_subscribe', '0'),
 			'mailchimp_checkbox_defaults' => $checkbox,
 			'mailchimp_checkbox_action' => isset($input['mailchimp_checkbox_action']) ? $input['mailchimp_checkbox_action'] : $this->getOption('mailchimp_checkbox_action', 'woocommerce_after_checkout_billing_form'),

--- a/admin/partials/tabs/newsletter_settings.php
+++ b/admin/partials/tabs/newsletter_settings.php
@@ -91,9 +91,10 @@ $list_is_configured = isset($options['mailchimp_list']) && (!empty($options['mai
         <span><?php esc_html_e('Newsletter Label', 'mailchimp-woocommerce');?></span>
     </legend>
     <label for="<?php echo $this->plugin_name; ?>-newsletter-checkbox-label">
-        <input style="width: 30%;" type="text" id="<?php echo $this->plugin_name; ?>-newsletter-checkbox-label" name="<?php echo $this->plugin_name; ?>[newsletter_label]" value="<?php echo isset($options['newsletter_label']) ? $options['newsletter_label'] : __('Subscribe to our newsletter', 'mailchimp-woocommerce'); ?>" />
+        <input style="width: 30%;" type="text" id="<?php echo $this->plugin_name; ?>-newsletter-checkbox-label" name="<?php echo $this->plugin_name; ?>[newsletter_label]" value="<?php echo isset($options['newsletter_label']) ? esc_html($options['newsletter_label']) : esc_html__('Subscribe to our newsletter', 'mailchimp-woocommerce'); ?>" />
         <span><?php esc_html_e('Enter text for the opt-in checkbox', $this->plugin_name); ?></span>
     </label>
+    <p class="description"><?= esc_html(__('HTML tags allowed: <a href="" target="" title=""></a> and <br>', 'mailchimp-woocommerce')); ?></p>
 </fieldset>
 
 <h4 style="padding-top: 1em;font-weight:normal;"><?php esc_html_e('Checkbox Display Options', 'mailchimp-woocommerce');?></h4>


### PR DESCRIPTION
It is only allowing <a href="" target="" title=""></a> and <br>. All other html tags and atts are stripped down.