### PR TITLE
Fix Order ID

### DIFF
--- a/includes/api/class-mailchimp-woocommerce-transform-orders-wc3.php
+++ b/includes/api/class-mailchimp-woocommerce-transform-orders-wc3.php
@@ -73,7 +73,7 @@ class MailChimp_WooCommerce_Transform_Orders
             return $order->flagAsPrivacyProtected(true);
         }
 
-        $order->setId($woo->get_order_number());
+        $order->setId($woo->get_id());
 
         // if we have a campaign id let's set it now.
         if (!empty($this->campaign_id)) {


### PR DESCRIPTION
The correct way of getting the order ID is using the method `get_id()` and not `get_order_number()`.
The purpose of `get_order_number()` is to get the order number for display only

That should fix #445 