### PR TITLE
Prevent empty Order Campaign ID to be fetched from MC API

### DIFF
--- a/includes/api/assets/class-mailchimp-order.php
+++ b/includes/api/assets/class-mailchimp-order.php
@@ -212,7 +212,7 @@ class MailChimp_WooCommerce_Order
     {
         $api = MailChimp_WooCommerce_MailChimpApi::getInstance();
         $cid = trim($id);
-        if (($campaign = $api->getCampaign($cid, false))) {
+        if (!empty($cid) && $campaign = $api->getCampaign($cid, false)) {
             $this->campaign_id = $campaign['id'];
         }
         return $this;


### PR DESCRIPTION
Fixes #448