### PR TITLE
Fix coupon add bug

### DIFF
--- a/includes/api/class-mailchimp-api.php
+++ b/includes/api/class-mailchimp-api.php
@@ -1202,7 +1202,7 @@ class MailChimp_WooCommerce_MailChimpApi
     public function addPromoRule($store_id, MailChimp_WooCommerce_PromoRule $rule, $throw = true)
     {
         try {
-            if (($response = $this->updatePromoRule($store_id, $rule, $throw))) {
+            if (($response = $this->updatePromoRule($store_id, $rule, false))) {
                 return $response;
             }
             $data = $this->post("ecommerce/stores/{$store_id}/promo-rules", $rule->toArray());
@@ -1368,7 +1368,7 @@ class MailChimp_WooCommerce_MailChimpApi
     public function addPromoCodeForRule($store_id, MailChimp_WooCommerce_PromoRule $rule, MailChimp_WooCommerce_PromoCode $code, $throw = true)
     {
         try {
-            if (($result = $this->updatePromoCodeForRule($store_id, $rule, $code, $throw))) {
+            if (($result = $this->updatePromoCodeForRule($store_id, $rule, $code, false))) {
                 return $result;
             }
             $data = $this->post("ecommerce/stores/{$store_id}/promo-rules/{$rule->getId()}/promo-codes", $code->toArray());


### PR DESCRIPTION
Disable coupon add error handling on patch fail. This bug was introduced in c9c5f7b5e269b347245d64d92326fb6344e685ce