### PR TITLE
Register page with WooCommerce Navigation.

### DIFF
--- a/admin/class-mailchimp-woocommerce-admin.php
+++ b/admin/class-mailchimp-woocommerce-admin.php
@@ -136,6 +136,21 @@ class MailChimp_WooCommerce_Admin extends MailChimp_WooCommerce_Options {
 	}
 
 	/**
+	 * Include the new Navigation Bar the Admin page.
+	 */
+	public function add_woocommerce_navigation_bar() {
+		if ( function_exists( 'wc_admin_connect_page' ) ) {
+			wc_admin_connect_page(
+				array(
+					'id'        => $this->plugin_name,
+					'screen_id' => 'toplevel_page_mailchimp-woocommerce',
+					'title'     => __( 'Mailchimp for WooCommerce', 'mailchimp-for-woocommerce' ),
+				)
+			);
+		}
+	}
+
+	/**
 	 * check if current user can view options pages/ save plugin options
 	 */
 	public function mailchimp_woocommerce_option_page_capability() {

--- a/includes/class-mailchimp-woocommerce.php
+++ b/includes/class-mailchimp-woocommerce.php
@@ -226,7 +226,10 @@ class MailChimp_WooCommerce
 		// Add menu item
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_plugin_admin_menu');
 
-		// Add Settings link to the plugin
+        // Add WooCommerce Navigation Bar
+        $this->loader->add_action('admin_menu', $plugin_admin, 'add_woocommerce_navigation_bar');
+
+        // Add Settings link to the plugin
 		$plugin_basename = plugin_basename( plugin_dir_path( __DIR__ ) . $this->plugin_name . '.php');
 		$this->loader->add_filter('plugin_action_links_' . $plugin_basename, $plugin_admin, 'add_action_links');
 


### PR DESCRIPTION
Greetings!

I'm working on a blog post for the WooCommerce developers blog about how to register pages with the new WooCommerce Navigation bar that is shipping in WooCommerce 4.0. Since I knew this plugin created a custom menu item / page - it seemed like a good example to show how to register a custom PHP page to use the new navigation bar.

__Before__
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/22080/75385428-9798d080-5894-11ea-8f0f-4e79f1a617d8.png">

__After__
<img width="1216" alt="Mailchimp - WooCommerce Setup ‹ ecomm woo test — WordPress 2020-02-26 12-35-57" src="https://user-images.githubusercontent.com/22080/75385460-a1bacf00-5894-11ea-9319-6cef28d1d11c.png">

__To Test__

- Checkout this branch on a site that is running either WooCommerce Admin, or Beta or RC1 of WooCommerce 4.0
- Visit the MC settings page and verify that the new navigation bar is shown
- Repeat the steps on a site that is running an older version of Woo and that doesn't have wc-admin installed. Verify that no navigation bar is shown.