### PR TITLE
Fix incorrect direct property access on WC_Product

### DIFF
--- a/includes/api/class-mailchimp-woocommerce-transform-products.php
+++ b/includes/api/class-mailchimp-woocommerce-transform-products.php
@@ -258,7 +258,8 @@ class MailChimp_WooCommerce_Transform_Products
 
     public function getProductImage($post)
     {
-        $meta = get_post_meta($post->ID);
+        $id = is_a($post, 'WC_Product') ? $post->get_id() : $post->ID;
+        $meta = get_post_meta($id);
         $key = '_thumbnail_id';
         $image_key = $this->getProductImageKey();
         if ($meta && is_array($meta) && array_key_exists($key, $meta) && isset($meta[$key][0])) {
@@ -270,7 +271,7 @@ class MailChimp_WooCommerce_Transform_Products
                 return $img[0];
             }
         }
-        return get_the_post_thumbnail_url($post->ID, $image_key);
+        return get_the_post_thumbnail_url($id, $image_key);
     }
 
     /**


### PR DESCRIPTION
This fixes a bug that generates:

```
PHP Notice:  ID was called <strong>incorrectly</strong>. Product properties should not be accessed directly. Backtrace: require_once('wp-admin/admin.php'), do_action('load-tools_page_action-scheduler'), WP_Hook->do_action, WP_Hook->apply_filters, ActionScheduler_AdminView->process_admin_ui, ActionScheduler_Abstract_ListTable->process_actions, ActionScheduler_Abstract_ListTable->process_row_actions, ActionScheduler_ListTable->row_action_run, ActionScheduler_ListTable->process_row_action, ActionScheduler_Abstract_QueueRunner->process_action, ActionScheduler_Action->execute, do_action_ref_array('MailChimp_WooCommerce_Single_Product'), WP_Hook->do_action, WP_Hook->apply_filters, MailChimp_Service->mailchimp_process_single_job, MailChimp_WooCommerce_Single_Product->handle, MailChimp_WooCommerce_Single_Product->process, MailChimp_WooCommerce_Transform_Products->transform, MailChimp_WooCommerce_Transform_Products->variant, MailChimp_WooCommerce_Transform_Products->getProductImage, WC_Abstract_Legacy_Product->__get, wc_doing_it_w in /Users/pedger/Devel/vextras/rawvextras/wp-includes/functions.php on line 4986
```