### PR TITLE
Fix getCampaignTrackingID when stored in session

### DIFF
--- a/includes/class-mailchimp-woocommerce-service.php
+++ b/includes/class-mailchimp-woocommerce-service.php
@@ -472,7 +472,7 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
     {
         $cookie = $this->cookie('mailchimp_campaign_id', false);
         if (empty($cookie)) {
-            $cookie = $this->getWooSession('mailchimp_tracking_id', false);
+            $cookie = $this->getWooSession('mailchimp_campaign_id', false);
         }
 
         return $cookie;


### PR DESCRIPTION
`setCampaignTrackingID ` sets `mailchimp_campaign_id` rather than `mailchimp_tracking_id`.