### PR TITLE
Fix checking if WooCommerce Admin is active

### DIFF
--- a/admin/class-mailchimp-woocommerce-admin.php
+++ b/admin/class-mailchimp-woocommerce-admin.php
@@ -259,7 +259,7 @@ class MailChimp_WooCommerce_Admin extends MailChimp_WooCommerce_Options {
 	public function initial_notice() {
 		if (!mailchimp_is_configured()) {
 			// If WC_Admin_Notes doesn't exist, show normal wordpress admin notice...
-			if ( ! class_exists( '\Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
+			if ( ! WC()->is_wc_admin_active() ) {
 				$class = 'notice notice-warning is-dismissible';
 				$message = sprintf(
 					/* translators: Placeholders %1$s - opening strong HTML tag, %2$s - closing strong HTML tag, %3$s - opening link HTML tag, %4$s - closing link HTML tag */


### PR DESCRIPTION
Hey there!

**Describe the bug**

I am using an [official WooCommerce filter](https://woocommerce.wp-a2z.org/oik_hook/woocommerce_admin_disabled/) to disable WooCommerce Admin in my site:
`add_filter( 'woocommerce_admin_disabled', '__return_true' );`

When Mailchimp is trying to display a notice when Mailchimp is installed but not yet configured, fatal error happens:

```
Fatal error: Uncaught Exception: Invalid data store. in /wp-content/plugins/woocommerce/includes/class-wc-data-store.php:107 Stack trace:
 #0 /wp-content/plugins/woocommerce/includes/class-wc-data-store.php(139): WC_Data_Store->__construct(‘admin’)
 #1 /wp-content/plugins/mailchimp-for-woocommerce/admin/class-mailchimp-woocommerce-admin.php(283): WC_Data_Store::load(‘admin-note’)
 #2 /wp-includes/class-wp-hook.php(287): MailChimp_WooCommerce_Admin->initial_notice(”) 
 #3 /wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters(NULL, Array)
 #4 /wp-includes/plugin.php(478): WP_Hook->do_action(Array)
 #5 /wp-admin/admin-header.php(292): do_action(‘admin_notices’) 
 #6 /wp-admin/plugins.php(603): require_once(‘…’) #7 {main} thrown in /wp-content/plugins/woocommerce/includes/class-wc-data-store.php on line 107
```
** Solution**
It seems to me that Mailchimp is not correctly checking if WooCommerce Admin is activated. Maybe you would choose a different approach to checking this? There is a WooCommerce function for this: **[is_wc_admin_active](https://woocommerce.wp-a2z.org/oik_api/woocommerceis_wc_admin_active/)**



**To Reproduce**
Steps to reproduce the behavior:
1. Use fresh WooCommerce installation
2. Apply the [filter](https://gist.magentonotes.com/jmau111/02401665ed8c49abad6bfc1854935282)
3. Make sure that WooCommerce Status shows WooCommerce Admin as Inactive: https://wpdesk.me/po/hnnatxCXBv.png
4. Activate Mailchimp for WooCommerce
5. Fatal error on the frontend of the admin panel.

**Operating environment:**
- Plugin version: 2.4.7
- WooCommerce version: 4.6.1
- Wordpress version: 5.5.1
- PHP version: 7.3.23

