### PR TITLE
Register WooCommerce navigation items

### DIFF
--- a/admin/class-mailchimp-woocommerce-admin.php
+++ b/admin/class-mailchimp-woocommerce-admin.php
@@ -10,6 +10,8 @@
  * @subpackage MailChimp_WooCommerce/admin
  */
 
+use \Automattic\WooCommerce\Admin\Features\Navigation\Menu;
+
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -161,6 +163,20 @@ class MailChimp_WooCommerce_Admin extends MailChimp_WooCommerce_Options {
 			mailchimp_get_allowed_capability(),
 			$this->plugin_name,
 			array($this, 'display_plugin_setup_page')
+		);
+
+		// Add the WooCommerce navigation items if the feauture exists.
+		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu' ) ) {
+			return;
+		}
+
+		Menu::add_plugin_item(
+			array(
+				'id'         => 'mailchimp-for-woocommerce',
+				'title'      => __( 'Mailchimp', 'mailchimp-for-woocommerce' ),
+				'capability' => mailchimp_get_allowed_capability(),
+				'url'        => $this->plugin_name,
+			)
 		);
 	}
 


### PR DESCRIPTION
Adds the menu items for the new WC nav experience.

### Screenshots
<img width="673" alt="Screen Shot 2020-11-12 at 1 11 35 PM" src="https://user-images.githubusercontent.com/10561050/98979162-02ed0600-24e9-11eb-89f6-4adc7b87f9eb.png">


### Testing

1. Clone and install/activate https://github.com/woocommerce/woocommerce-admin
1. Enable the navigation feature at `wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
1. Check that the "Mailchimp" extension is registered and menu items work as expected.