### PR TITLE
Use relative path for vendor gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 .idea/
 _test.php
-vendor/
+/vendor/


### PR DESCRIPTION
By making the vendor directory non-relative in gitignore the vendor
directory within includes gets ignored too.

It's a problem if you push the plugin into a git repo from a project but also as the `includes/vendor` library is required for the built version of the plugin so think it makes sense to not ignore this too. 

Hope that makes sense! Thanks!