### PR TITLE
Preserve value for if the cart was updated in return value.

### DIFF
--- a/includes/class-mailchimp-woocommerce-service.php
+++ b/includes/class-mailchimp-woocommerce-service.php
@@ -196,7 +196,7 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
     public function handleCartUpdated($updated = null)
     {
         if (mailchimp_carts_disabled()) {
-            return false;
+            return $updated;
         }
 
         if ($updated === false || $this->is_admin || $this->cart_was_submitted || !mailchimp_is_configured()) {
@@ -225,7 +225,7 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
                 }
                 if ($cached_status !== 'subscribed') {
                     mailchimp_debug('filter', "preventing {$user_email} from submitting cart data due to subscriber settings.");
-                    return false;
+                    return $updated;
                 }
             }
 


### PR DESCRIPTION
b20b9794f5166899473d42e9e3d5de3f3797431a introduced this new functionality to return early depending on these settings.

However, this breaks the return value for the `woocommerce_update_cart_action_cart_updated` filter for any filters that
run before this code. The value of `$cart_updated` gets lost here if it was `true` so the cart never saves for other custom code or plugins.

This patch returns the passed in value still allowing this function to return early but preserves the `$cart_updated` value from other plugins.