### PR TITLE
Initial setup for filtering jobs before queuing

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -196,7 +196,18 @@ function mailchimp_handle_or_queue(Mailchimp_Woocommerce_Job $job, $delay = 0)
         // tell the system the order is already queued for processing in this saving process - and we don't need to process it again.
         set_site_transient( "mailchimp_order_being_processed_{$job->id}", true, 30);
     }
-    
+
+	// Allow sites to alter whether the order or product is synced.
+	// $job should contain at least the ID of the order/product as $job->id.
+	if (
+		( ( $job instanceof \MailChimp_WooCommerce_Single_Order )
+			&& ! apply_filters( 'mailchimp_should_push_order', $should_push = true, $order_id = $job->id ) )
+		|| ( ( $job instanceof \MailChimp_WooCommerce_Single_Product )
+			&& ! apply_filters( 'mailchimp_should_push_product', $should_push = true, $product_id = $job->id ) ) ) {
+		mailchimp_log( 'action_scheduler.queue_job', 'Exiting job due to filter result' );
+		return null;
+	}
+
     $as_job_id = mailchimp_as_push($job, $delay);
     
     if (!is_int($as_job_id)) {


### PR DESCRIPTION
This PR attempts to implement the feature request raised in https://wordpress.org/support/topic/filter-to-exclude-certain-products/#post-15737115 where sites could exclude certain products or orders from being synced to MailChimp through the use of a filter.

Example filter usage:

```
function maybe_exclude_product_from_syncing( $should_push, $product_id ): bool {
	if ( has_term( 'exclude_from_sync', 'product_tag', $product_id ) ) {
		$should_push = false;
	}

	return $should_push;
}
add_filter( 'mailchimp_should_push_product', 'maybe_exclude_product_from_syncing', 10, 2 );
```

It's been tested with the example above through manually editing a product and adding/removing the example term `exclude_from_sync`.

Note that the call to `mailchimp_log` may be excessive, and could be removed or set to only log in debug contexts. 

Let me know what you think, happy to help with refactoring/refining as you see fit.