### PR TITLE
Add WP filters to products

### DIFF
--- a/includes/api/class-mailchimp-woocommerce-transform-coupons.php
+++ b/includes/api/class-mailchimp-woocommerce-transform-coupons.php
@@ -98,7 +98,7 @@ class MailChimp_WooCommerce_Transform_Coupons {
 		// attach the rule for use.
 		$code->attachPromoRule( $rule );
 
-		return $code;
+		return apply_filters('mailchimp_sync_promocode', $code, $resource);
 	}
 
 	/**

--- a/includes/api/class-mailchimp-woocommerce-transform-products.php
+++ b/includes/api/class-mailchimp-woocommerce-transform-products.php
@@ -62,7 +62,7 @@ class MailChimp_WooCommerce_Transform_Products {
 
 		$product->addVariant( $variant );
 
-		return $product;
+		return apply_filters('mailchimp_sync_lineitem', $product);
 	}
 
 	/**
@@ -129,7 +129,7 @@ class MailChimp_WooCommerce_Transform_Products {
 			$product->addVariant( $product_variant );
 		}
 
-		return $product;
+		return apply_filters('mailchimp_sync_product', $product, $woo);
 	}
 
 	/**


### PR DESCRIPTION
Adding these filters will allow developers to push additional product information to Mailchimp. This can be used to add custom vendors without using woocommerce-product-vendors, or add product-types and manipulate other information.


Example usage for the mailchimp_sync_product filter that adds a vendor and a productType

```
add_filter('mailchimp_sync_product', 'add_attributes_to_mc', 10, 2);
function add_attributes_to_mc($mc_product, $wc_product){

    /* if a brand is stored as a product attribute */
    $vendor = $wc_product->get_attribute('pa_brand');
    $mc_product->setVendor( $vendor );
    
    /* get the highest level product category to set as product type */
    $categories = get_the_terms( $wc_product->get_id(), 'product_cat' );
    $main_category = 'not_set';
    foreach ($categories as $category) {
        if($category->parent == 0){
            $main_category = $category->name;
        }
    }
    $mc_product->setType($main_category);
    return $mc_product;
}
```