### PR TITLE
Prevent Store API validation errors when the 'optin' field has a null value

### DIFF
--- a/blocks/woocommerce-blocks-integration.php
+++ b/blocks/woocommerce-blocks-integration.php
@@ -187,11 +187,11 @@ class Mailchimp_Woocommerce_Newsletter_Blocks_Integration implements Integration
 					return array(
 						'optin' => array(
 							'description' => __( 'Subscribe to marketing opt-in.', 'mailchimp-newsletter' ),
-							'type'        => 'boolean',
+							'type'        => array( 'boolean', 'null' ),
 							'context'     => array(),
 							'arg_options' => array(
 								'validate_callback' => function( $value ) {
-									if ( ! is_bool( $value ) ) {
+									if ( ! is_null( $value ) && ! is_bool( $value ) ) {
 										return new WP_Error( 'api-error', 'value of type ' . gettype( $value ) . ' was posted to the newsletter optin callback' );
 									}
 									return true;

--- a/blocks/woocommerce-blocks-integration.php
+++ b/blocks/woocommerce-blocks-integration.php
@@ -196,6 +196,15 @@ class Mailchimp_Woocommerce_Newsletter_Blocks_Integration implements Integration
 									}
 									return true;
 								},
+								'sanitize_callback' => function ( $value ) {
+									if ( is_bool( $value ) ) {
+										return $value;
+									}
+
+									// Return a boolean when "null" is passed,
+									// which is the only non-boolean value allowed.
+									return false;
+								},
 							),
 						),
                         'gdprFields' => array(


### PR DESCRIPTION
### Summary

This PR is intended to solve an issue between [WooPay](https://woocommerce.com/woopay/) and Mailchimp for WooCommerce so that merchants can use both products together.

When an order gets created via the Store API, the 'optin' field expected by Mailchimp will be `null`. Right now, the `validate_callback` returns a `WP_Error` when the value of this field is not a boolean. This results in the order not being created.

### Proposed changes

- Accept a `null` value for the `optin` field.
- Sanitize this `null` value into a boolean, so the expected type is still received.

### Testing

I've tested this on WooPay's end and things are working as expected; the order does get created.

We'd just need to ensure things continue to work as usual for the regular flow with Blocks. I've tested this and things look as they were before these changes. Passing this to you to double-check.