### PR TITLE
2.7.7 - quickfix for newly created users from admin dashboard. 

### DIFF
--- a/includes/api/class-mailchimp-api.php
+++ b/includes/api/class-mailchimp-api.php
@@ -219,7 +219,7 @@ class MailChimp_WooCommerce_MailChimpApi {
 	public function subscribe( $list_id, $email, $subscribed = '1', $merge_fields = array(), $list_interests = array(), $language = null, $gdpr_fields = null ) {
 		if ( $subscribed === '1' ) {
             $status = 'subscribed';
-		} elseif ( $subscribed === '0' ) {
+		} elseif ( $subscribed === '0' || empty($subscribed) ) {
             $status = 'transactional';
         } else {
             $status = $subscribed;

--- a/includes/processes/class-mailchimp-woocommerce-user-submit.php
+++ b/includes/processes/class-mailchimp-woocommerce-user-submit.php
@@ -318,7 +318,7 @@ class MailChimp_WooCommerce_User_Submit extends Mailchimp_Woocommerce_Job
 
                 try {
                     $uses_doi = isset($status_meta['requires_double_optin']) && $status_meta['requires_double_optin'];
-                    $status_if_new = $uses_doi && $this->subscribed ? 'pending' : $this->subscribed;
+                    $status_if_new = $uses_doi && (bool) $this->subscribed ? 'pending' : $this->subscribed;
 
                     $api->subscribe($list_id, $user->user_email, $status_if_new, $merge_fields, null, $language, $gdpr_fields);
 


### PR DESCRIPTION
(when mailchimp_woocommerce_is_subscribed is empty = set transactional status)