### PR TITLE
Update Composer file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,13 @@
 {
+	"license": "GPL-2.0-or-later",
 	"require-dev": {
-    	"phpcompatibility/php-compatibility": "*",
+		"phpcompatibility/php-compatibility": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6",
 		"phpcompatibility/phpcompatibility-wp": "^2.1"
+	},
+	"require": {
+		"php": "^7|^8",
+		"ext-pcre": "*"
 	},
 	"prefer-stable" : true
 }


### PR DESCRIPTION
- Clarifies the required PHP version range (as determined by linting).

*For evidence of linting results, refer to the two most recent workflow checks at https://github.com/Maikuolan/mc-woocommerce/commits/patch-1*

- Clarifies the licensing for `mc-woocommerce` according to its `LICENSE.txt` file (GNU/GPLv2).