### PR TITLE
new option: mailchimp-woocommerce-enable-landing-tracking

### DIFF
--- a/admin/class-mailchimp-woocommerce-admin.php
+++ b/admin/class-mailchimp-woocommerce-admin.php
@@ -1428,6 +1428,7 @@ class MailChimp_WooCommerce_Admin extends MailChimp_WooCommerce_Options {
                 'mailchimp_cart_tracking'       => isset( $input['mailchimp_cart_tracking'] ) ? $input['mailchimp_cart_tracking'] : 'all',
                 'mailchimp_user_tags'           => isset( $input['mailchimp_user_tags'] ) ? implode( ',', $sanitized_tags ) : $this->getOption( 'mailchimp_user_tags' ),
                 'mailchimp_ongoing_sync_status' => isset( $input['mailchimp_ongoing_sync_status'] ) ? (bool) $input['mailchimp_ongoing_sync_status'] : '0',
+                'mailchimp-woocommerce-enable-landing-tracking' => isset( $input['mailchimp-woocommerce-enable-landing-tracking'] ) ? (bool) $input['mailchimp-woocommerce-enable-landing-tracking'] : false,
             ));
             $key = !$connected ? 'review_settings' : 'navigation_audience';
             $events = ['0' => 'sync_as_non_subscribed', '1' => 'sync_as_subscribed', '2' => 'sync_existing_only'];
@@ -1443,6 +1444,7 @@ class MailChimp_WooCommerce_Admin extends MailChimp_WooCommerce_Options {
                 'mailchimp_cart_tracking'       => isset( $input['mailchimp_cart_tracking'] ) ? $input['mailchimp_cart_tracking'] : 'all',
                 'mailchimp_user_tags'           => isset( $input['mailchimp_user_tags'] ) ? implode( ',', $sanitized_tags ) : $this->getOption( 'mailchimp_user_tags' ),
                 'mailchimp_ongoing_sync_status' => isset( $input['mailchimp_ongoing_sync_status'] ) ? (bool) $input['mailchimp_ongoing_sync_status'] : '0',
+                'mailchimp-woocommerce-enable-landing-tracking' => isset( $input['mailchimp-woocommerce-enable-landing-tracking'] ) ? (bool) $input['mailchimp-woocommerce-enable-landing-tracking'] : false,
             );
         } else {
             $validate_campaign_settings = true;
@@ -1452,6 +1454,7 @@ class MailChimp_WooCommerce_Admin extends MailChimp_WooCommerce_Options {
                 'mailchimp_ongoing_sync_status' => isset( $input['mailchimp_ongoing_sync_status'] ) ? (bool) $input['mailchimp_ongoing_sync_status'] : $this->getOption('mailchimp_ongoing_sync_status', '1'),
                 'mailchimp_user_tags'           => isset( $input['mailchimp_user_tags'] ) ? implode( ',', $sanitized_tags ) : $this->getOption( 'mailchimp_user_tags' ),
                 'mailchimp_cart_tracking'       => isset( $input['mailchimp_cart_tracking'] ) ? $input['mailchimp_cart_tracking'] : 'all',
+                'mailchimp-woocommerce-enable-landing-tracking' => isset( $input['mailchimp-woocommerce-enable-landing-tracking'] ) ? (bool) $input['mailchimp-woocommerce-enable-landing-tracking'] : false,
             ));
         }
 

--- a/admin/v2/templates/confirmation/tabs/audience.php
+++ b/admin/v2/templates/confirmation/tabs/audience.php
@@ -87,7 +87,7 @@
                         </div>
                     </div>
                     <div class="mc-wc-import-list-sync-description">
-                        <?php esc_html_e( 'Warning: this may impact the performacne of your site.  Check with your hosting provider for more information about the impact of cookies on every page view.', 'mailchimp-for-woocommerce' ); ?>
+                        <?php esc_html_e( 'Warning: this may impact the performance of your site.  Check with your hosting provider for more information about the impact of cookies on every page view.', 'mailchimp-for-woocommerce' ); ?>
                     </div>
                 </div>
             </div>

--- a/admin/v2/templates/confirmation/tabs/audience.php
+++ b/admin/v2/templates/confirmation/tabs/audience.php
@@ -69,6 +69,33 @@
 
     <div class="mc-wc-tab-content-box has-underline">
         <div class="mc-wc-tab-content-title">
+            <h3><?php esc_html_e( 'Landing page tracking preferences', 'mailchimp-for-woocommerce' ); ?></h3>
+        </div>
+        <div class="mc-wc-tab-content-description-small">
+            <?php esc_html_e( 'Control tracking of the landing page via the mailchimp_landing_site cookie for visitors that are not logged in.  For logged in customers, this is not needed.', 'mailchimp-for-woocommerce' ); ?>
+        </div>
+        <?php $landing_tracking_enabled = ( array_key_exists( 'mailchimp-woocommerce-enable-landing-tracking', $options ) && ! is_null( $options['mailchimp-woocommerce-enable-landing-tracking'] ) ) ? (bool) $options['mailchimp-woocommerce-enable-landing-tracking'] : false; ?>
+        <div class="mc-wc-contact-import-ref-choose">
+            <div class="mc-wc-import-list-sync">
+                <div class="mc-wc-import-list-sync-item">
+                    <div class="mc-wc-import-list-sync-input">
+                        <div class="mc-wc-checkbox">
+                            <label class="mc-wc-checkbox-label fw-700">
+                                <input type="checkbox" name="<?php echo esc_attr( $this->plugin_name ); ?>[mailchimp-woocommerce-enable-landing-tracking]" value="1" <?php if ($landing_tracking_enabled) { echo "checked"; } ?>>
+                                <?php esc_html_e( 'Enable landing page tracking', 'mailchimp-for-woocommerce' ); ?>
+                            </label>
+                        </div>
+                    </div>
+                    <div class="mc-wc-import-list-sync-description">
+                        <?php esc_html_e( 'Warning: this may impact the performacne of your site.  Check with your hosting provider for more information about the impact of cookies on every page view.', 'mailchimp-for-woocommerce' ); ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mc-wc-tab-content-box has-underline">
+        <div class="mc-wc-tab-content-title">
             <h3><?php esc_html_e( 'Contact import preferences', 'mailchimp-for-woocommerce' ); ?></h3>
         </div>
         <div class="mc-wc-contact-import-ref-choose">

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -330,6 +330,13 @@ function mailchimp_carts_subscribers_only() {
 }
 
 /**
+ * @return bool
+ */
+function mailchimp_landing_tracking_enabled() {
+    return (bool) mailchimp_get_option('mailchimp-woocommerce-enable-landing-tracking', false);
+}
+
+/**
  * @param $email
  * @return string|null
  */

--- a/includes/class-mailchimp-woocommerce-service.php
+++ b/includes/class-mailchimp-woocommerce-service.php
@@ -978,7 +978,7 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
         // Catching images, videos and fonts file types
         preg_match("/^.*\.(ai|bmp|gif|ico|jpeg|jpg|png|ps|psd|svg|tif|tiff|fnt|fon|otf|ttf|3g2|3gp|avi|flv|h264|m4v|mkv|mov|mp4|mpg|mpeg|rm|swf|vob|wmv|aif|cda|mid|midi|mp3|mpa|ogg|wav|wma|wpl)$/i", $landing_site, $matches);
 
-        if (!empty($landing_site) && !wp_doing_ajax() && ( count($matches) == 0 ) && !$this->is_rest() ) {
+        if (!empty($landing_site) && !wp_doing_ajax() && ( count($matches) == 0 ) && !$this->is_rest() && mailchimp_landing_tracking_enabled() ) {
             mailchimp_set_cookie('mailchimp_landing_site', $landing_site, $this->getCookieDuration(), '/' );
             $this->setWooSession('mailchimp_landing_site', $landing_site);
         }


### PR DESCRIPTION
This adds a new option ( and UI ) to the plugin and disables the `mailchimp_landing_site` cookie by default.

---

The current Mailchimp WordPress plugin will start adding cookies to all page views the moment the plugin is activated.  You don't need to connect your site to a Mailchimp account for this to happen.

Having a cookie on every page view will cause sites with CDNs to bypass the CDN layer.  Activating this plugin immediately breaks the CDN cache.  That is fine if a site owner decides that the functionality of having a cookie on every page view is worth the trade off, but doing it by default is hurting the performance of sites by default.

I work at Automattic, and we've noticed this problem on WooCommerce sites with the Mailchimp plugin activated.

This has been brought up before - https://github.com/mailchimp/mc-woocommerce/issues/1225 - and there are code instructions for how to disable it - https://github.com/mailchimp/mc-woocommerce/wiki/Enable-or-Disable-Cookie-Filter - but most site owners are not going to get that far into it.  They expect a plugin from a reliable source like Mailchimp to not hurt the performance of their site by default.

Seven months ago Mailchimp indicated that they would look at this.  I haven't seen any updates since then, so I'm offering this PR as a starting place to preserve good site performance by default and make enabling the `mailchimp_landing_site` cookie opt-in by the site owner.

Hopefully this plugin aligns with the style and arrangement that Mailchimp is looking for in this plugin, but if not I'm happy to make what ever coding adjustments they want.