### PR TITLE
FIx of Fatal Error: handleProductUpdated() Argument #2 ($post_after) must be of type WP (Issue #1309)

### DIFF
--- a/includes/class-mailchimp-woocommerce-service.php
+++ b/includes/class-mailchimp-woocommerce-service.php
@@ -367,8 +367,13 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
      * @param WP_Post $post_before The post object as it exists after the update
      * @return void
      */
-    public function handleProductUpdated( int $post_ID, WP_Post $post_after, WP_Post $post_before )
+    public function handleProductUpdated( int $post_ID, ?WP_Post $post_after, ?WP_Post $post_before )
     {
+        // Ensure $post_after is a valid WP_Post
+        if ( ! $post_after instanceof WP_Post ) {
+            return;
+        }
+
         if ('product' !== $post_after->post_type) {
             return;
         }
@@ -378,7 +383,7 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
             return;
         }
 
-        /// old filter array('trash', 'auto-draft', 'draft', 'pending', 'private')
+        // 'draft', 'pending'
         if (in_array($post_after->post_status, array('trash', 'auto-draft'))) {
             mailchimp_log('product.update.blocked', "product {$post_ID} was blocked because status is {$post_after->post_status}");
             return;


### PR DESCRIPTION
## Summary
Fixes a fatal error in Mailchimp for WooCommerce when updating or deleting products. WordPress can pass `null` for `$post_after` or `$post_before` in the `post_updated` hook, but the function signature required `WP_Post`, causing a TypeError.

## Fix
- Updated method signature to accept nullable parameters:
```

public function handleProductUpdated( int $post_ID, ?WP_Post $post_after, ?WP_Post $post_before )

```
- Added safeguard inside the function:

```
if ( ! $post_after instanceof WP_Post ) {
    return;
}
```

**Testing**

- Product updates and deletions no longer trigger fatal errors.
- Tested on WordPress 6.x, WooCommerce latest, PHP 8.1/8.2

