### PR TITLE
Fix: Cart update overwrites subscriber status to transactional (Story 48718)

### DIFF
--- a/includes/class-mailchimp-woocommerce-service.php
+++ b/includes/class-mailchimp-woocommerce-service.php
@@ -281,7 +281,7 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
                 $handler = new MailChimp_WooCommerce_Cart_Update($uid, $user_email, $this->cart, $language, $session_id);
 
                 // if they had the checkbox checked - go ahead and subscribe them if this is the first post.
-                //$handler->setStatus($this->cart_subscribe);
+                $handler->setStatus($this->cart_subscribe);
                 $handler->prepend_to_queue = true;
                 mailchimp_handle_or_queue($handler);
             }

--- a/includes/processes/class-mailchimp-woocommerce-cart-update.php
+++ b/includes/processes/class-mailchimp-woocommerce-cart-update.php
@@ -175,8 +175,9 @@ class MailChimp_WooCommerce_Cart_Update extends Mailchimp_Woocommerce_Job
             }
 
             // Maybe sync subscriber to set correct member.language
-            // TODO this function is doing nothing except pushing the log message with no actual process
-            mailchimp_member_data_update($this->email, $this->user_language, 'cart');
+            // Pass subscriber status if user opted in via newsletter checkbox
+		$subscriber_status = $this->status ? 'subscribed' : 'transactional';
+            mailchimp_member_data_update($this->email, $this->user_language, 'cart', $subscriber_status);
 
         } catch (MailChimp_WooCommerce_RateLimitError $e) {
             sleep(3);


### PR DESCRIPTION
## Problem
When users checked the newsletter subscription checkbox during checkout, their status was incorrectly set to `transactional` instead of `subscribed`.

## Root Cause
1. `includes/class-mailchimp-woocommerce-service.php:284` - `setStatus()` was commented out
2. `includes/processes/class-mailchimp-woocommerce-cart-update.php:177` - `mailchimp_member_data_update()` called without 4th param (defaults to `transactional`)

## Fix
- Uncommented `setStatus()` to pass subscriber preference from checkout form
- Added `$subscriber_status` logic to respect user opt-in choice

## Testing
- Add item to cart with newsletter checkbox enabled
- Verify Mailchimp member status is `subscribed` (not `transactional`)

Fixes Shortcut story 48718