### PR TITLE
fix: Include SMS consent data in customer payload when available

### DIFF
--- a/includes/api/assets/class-mailchimp-customer.php
+++ b/includes/api/assets/class-mailchimp-customer.php
@@ -138,6 +138,28 @@ class MailChimp_WooCommerce_Customer {
 		return $this;
 	}
 
+
+	/**
+	 * @param bool $sms_opt_in_status
+	 * @return MailChimp_WooCommerce_Customer
+	 */
+	public function setSmsOptInStatus( $sms_opt_in_status ) {
+		if ( is_bool( $sms_opt_in_status ) ) {
+			$this->sms_opt_in_status = $sms_opt_in_status;
+		} else {
+			$this->sms_opt_in_status = $sms_opt_in_status === '1' || $sms_opt_in_status === 1 || $sms_opt_in_status === true;
+		}
+		return $this;
+	}
+
+	/**
+	 * @param string|null $phone_number
+	 * @return MailChimp_WooCommerce_Customer
+	 */
+	public function setPhoneNumber( $phone_number ) {
+		$this->phone_number = $phone_number;
+		return $this;
+	}
     /**
 	 * @return null
 	 */
@@ -410,20 +432,26 @@ class MailChimp_WooCommerce_Customer {
 	public function toArray() {
 		$address = $this->getAddress()->toArray();
 
-		return mailchimp_array_remove_empty(
-			array(
-				'id'            => (string) $this->getId(),
-				'email_address' => (string) $this->getEmailAddress(),
-				'opt_in_status' => (bool)$this->getOptInStatus(),
-                'marketing_status_updated_at' => $this->getOptInStatusTimeAsString(),
-                'company'       => (string) $this->getCompany(),
-                'first_name'    => (string) $this->getFirstName(),
-				'last_name'     => (string) $this->getLastName(),
-				// 'orders_count' => (int) $this->getOrdersCount(),
-				// 'total_spent' => floatval(number_format($this->getTotalSpent(), 2, '.', '')),
-				'address'       => ( empty( $address ) ? null : $address ),
-			)
+		$array = array(
+			'id'            => (string) $this->getId(),
+			'email_address' => (string) $this->getEmailAddress(),
+			'opt_in_status' => (bool)$this->getOptInStatus(),
+			'marketing_status_updated_at' => $this->getOptInStatusTimeAsString(),
+			'company'       => (string) $this->getCompany(),
+			'first_name'    => (string) $this->getFirstName(),
+			'last_name'     => (string) $this->getLastName(),
+			// 'orders_count' => (int) $this->getOrdersCount(),
+			// 'total_spent' => floatval(number_format($this->getTotalSpent(), 2, '.', '')),
+			'address'       => ( empty( $address ) ? null : $address ),
 		);
+
+		// Add SMS fields if SMS consent is enabled
+		$sms_phone = $this->getPhoneNumber();
+		if ( $this->getSmsOptInStatus() && !empty( $sms_phone ) ) {
+			$array['phone_number'] = (string) $sms_phone;
+		}
+
+		return mailchimp_array_remove_empty( $array );
 	}
 
 	/**

--- a/includes/processes/class-mailchimp-woocommerce-single-customer.php
+++ b/includes/processes/class-mailchimp-woocommerce-single-customer.php
@@ -88,6 +88,17 @@ class MailChimp_Woocommerce_Single_Customer extends Mailchimp_Woocommerce_Job
         $customer->setOptInStatus(false);
         $customer->fromArray($data);
 
+
+		// Retrieve and set SMS consent data if user exists
+		if ($wordpress_user_id && $user) {
+			$sms_consent = get_user_meta($wordpress_user_id, 'mailchimp_woocommerce_sms_consent_subscribed', true);
+			$sms_phone = get_user_meta($wordpress_user_id, 'mailchimp_woocommerce_sms_consent_phone', true);
+
+			if ($sms_consent && !empty($sms_phone)) {
+				$customer->setSmsOptInStatus($sms_consent);
+				$customer->setPhoneNumber($sms_phone);
+			}
+		}
         // set the address from the customer lookup table
         $customer->getAddress()->setCity($this->customer_data->city ?? '');
         $customer->getAddress()->setCountry($this->customer_data->country ?? '');


### PR DESCRIPTION
Issue: Customer payloads were not including SMS consent data (phone_number field) even when users had opted in via the SMS consent checkbox.

Root cause: The setSmsOptInStatus() and setPhoneNumber() methods existed on the Customer object, but the data was never retrieved from user_meta or added to the toArray() payload.

Changes:
- Added getSmsOptInStatus() and setPhoneNumber() methods to MailChimp_WooCommerce_Customer
- Updated toArray() to conditionally include phone_number when SMS consent is true
- Added SMS consent data retrieval from user_meta in single customer sync process

This ensures that when a customer opts in to SMS marketing via the checkout SMS consent checkbox, their phone number is properly synced to Mailchimp with their contact record.

Fixes #48718