### PR TITLE
Add debug tracing for WooCommerce sync jobs

### DIFF
--- a/includes/processes/class-mailchimp-woocommerce-abstract-sync.php
+++ b/includes/processes/class-mailchimp-woocommerce-abstract-sync.php
@@ -88,8 +88,23 @@ abstract class MailChimp_WooCommerce_Abstract_Sync extends Mailchimp_Woocommerce
         $this->setData('sync.'.$this->getResourceType().'.started_at', time());
 
         $page = $this->getCurrentPage();
+        $total_pages = ceil((int)$post_count / $this->items_per_page);
 
-        while ($page - 1 <= ceil((int)$post_count / $this->items_per_page)) {
+        mailchimp_debug('sync.pagination.trace', 'creating sync managers', array(
+            'resource_type' => $this->getResourceType(),
+            'record_count' => (int) $post_count,
+            'items_per_page' => (int) $this->items_per_page,
+            'start_page' => (int) $page,
+            'total_pages' => (int) $total_pages,
+        ));
+
+        while ($page - 1 <= $total_pages) {
+            mailchimp_debug('sync.pagination.trace', 'queueing page sync manager', array(
+                'resource_type' => $this->getResourceType(),
+                'page' => (int) $page,
+                'total_pages' => (int) $total_pages,
+            ));
+
             $this->spawn($page);
             $page++;
         }
@@ -104,6 +119,11 @@ abstract class MailChimp_WooCommerce_Abstract_Sync extends Mailchimp_Woocommerce
         $next = new static($page);
         mailchimp_handle_or_queue($next);
         $this->setResourcePagePointer(($page), $this->getResourceType());
+
+        mailchimp_debug('sync.pagination.trace', 'queued page sync manager', array(
+            'resource_type' => $this->getResourceType(),
+            'page' => (int) $page,
+        ));
     }
 
 	/**
@@ -178,10 +198,20 @@ abstract class MailChimp_WooCommerce_Abstract_Sync extends Mailchimp_Woocommerce
             }
         }
 
+        mailchimp_debug('sync.pagination.trace', 'loading page resources', array(
+            'resource_type' => $this->getResourceType(),
+            'page' => (int) $this->getCurrentPage(),
+            'items_per_page' => (int) $this->items_per_page,
+        ));
+
         $page = $this->getResources();
 
         if (empty($page)) {
             mailchimp_debug(get_called_class().'@handle', 'could not find any more '.$this->getResourceType().' records ending on page '.$this->getResourcePagePointer());
+            mailchimp_debug('sync.pagination.trace', 'empty page response', array(
+                'resource_type' => $this->getResourceType(),
+                'page' => (int) $this->getCurrentPage(),
+            ));
             // call the completed event to process further
             $this->resourceComplete($this->getResourceType());
             $this->complete();
@@ -190,6 +220,12 @@ abstract class MailChimp_WooCommerce_Abstract_Sync extends Mailchimp_Woocommerce
         }
 
         mailchimp_debug(get_called_class().'@handle', $this->getResourceType()." :: {$page->count}");
+        mailchimp_debug('sync.pagination.trace', 'loaded page resources', array(
+            'resource_type' => $this->getResourceType(),
+            'page' => (int) $this->getCurrentPage(),
+            'count' => (int) $page->count,
+            'has_next_page' => isset($page->has_next_page) ? (bool) $page->has_next_page : null,
+        ));
 
         // if we've got a 0 count or less than items per page, that means we're done.
         if (!$page->count) {
@@ -206,24 +242,30 @@ abstract class MailChimp_WooCommerce_Abstract_Sync extends Mailchimp_Woocommerce
         }
 
         // iterate through the items and send each one through the pipeline based on this class.
+        $queued_count = 0;
         foreach ($page->items as $resource) {
             switch ($this->getResourceType()) {
                case 'customers':
                    mailchimp_handle_or_queue(new MailChimp_Woocommerce_Single_Customer($resource));
+                   $queued_count++;
                    break;
                case 'coupons':
                     mailchimp_handle_or_queue(new MailChimp_WooCommerce_SingleCoupon($resource));
+                   $queued_count++;
                    break;
                case 'products':
                     mailchimp_handle_or_queue(new MailChimp_WooCommerce_Single_Product($resource));
+                   $queued_count++;
                    break;
                case 'product_categories':
                     mailchimp_handle_or_queue(new Mailchimp_WooCommerce_Single_Product_Category($resource));
+                   $queued_count++;
                    break;
                case 'orders':
                     $order = new MailChimp_WooCommerce_Single_Order($resource);
                     $order->set_full_sync(true);
                     mailchimp_handle_or_queue($order);
+                   $queued_count++;
                    break;
                default:
                     mailchimp_log('sync.error', $this->getResourceType().' is not a valid resource.');
@@ -231,8 +273,18 @@ abstract class MailChimp_WooCommerce_Abstract_Sync extends Mailchimp_Woocommerce
            }
         }
 
+        mailchimp_debug('sync.pagination.trace', 'queued page resources', array(
+            'resource_type' => $this->getResourceType(),
+            'page' => (int) $this->getCurrentPage(),
+            'queued_count' => (int) $queued_count,
+        ));
+
         if (isset($page->has_next_page) && !$page->has_next_page) {
             $this->setResourceCompleteTime();
+            mailchimp_debug('sync.pagination.trace', 'last page reached', array(
+                'resource_type' => $this->getResourceType(),
+                'page' => (int) $this->getCurrentPage(),
+            ));
         }
 
         return false;
@@ -253,6 +305,12 @@ abstract class MailChimp_WooCommerce_Abstract_Sync extends Mailchimp_Woocommerce
             $this->setResourcePagePointer($current_page);
             $this->setData('sync.config.resync', false);
         }
+
+        mailchimp_debug('sync.pagination.trace', 'requesting paginated resources', array(
+            'resource_type' => $this->getResourceType(),
+            'page' => (int) $current_page,
+            'items_per_page' => (int) $this->items_per_page,
+        ));
 
         return $this->api()->paginate($this->getResourceType(), $current_page, $this->items_per_page);
     }

--- a/includes/processes/class-mailchimp-woocommerce-single-coupon.php
+++ b/includes/processes/class-mailchimp-woocommerce-single-coupon.php
@@ -57,11 +57,27 @@ class MailChimp_WooCommerce_SingleCoupon extends Mailchimp_Woocommerce_Job
             $api = mailchimp_get_api();
             $store_id = mailchimp_get_store_id();
 
+            mailchimp_debug('promo_code_submit.trace', 'start', array(
+                'coupon_id' => $this->id,
+            ));
+
             $transformer = new MailChimp_WooCommerce_Transform_Coupons();
             $code = $transformer->transform($this->id);
 
+            mailchimp_debug('promo_code_submit.trace', 'transformed WooCommerce coupon', array(
+                'coupon_id' => $this->id,
+                'promo_code' => $code->getCode(),
+                'promo_rule_id' => $code->getAttachedPromoRule()->getId(),
+            ));
+
             $api->addPromoRule($store_id, $code->getAttachedPromoRule());
             $api->addPromoCodeForRule($store_id, $code->getAttachedPromoRule(), $code);
+
+            mailchimp_debug('promo_code_submit.trace', 'completed Mailchimp coupon sync', array(
+                'coupon_id' => $this->id,
+                'promo_code' => $code->getCode(),
+                'promo_rule_id' => $code->getAttachedPromoRule()->getId(),
+            ));
 
             mailchimp_register_synced_resource('coupons');
 

--- a/includes/processes/class-mailchimp-woocommerce-single-customer.php
+++ b/includes/processes/class-mailchimp-woocommerce-single-customer.php
@@ -40,6 +40,11 @@ class MailChimp_Woocommerce_Single_Customer extends Mailchimp_Woocommerce_Job
         $store_id = mailchimp_get_store_id();
         $list_id = mailchimp_get_list_id();
 
+        mailchimp_debug('customer_submit.trace', 'start', array(
+            'customer_id' => $this->id,
+            'wordpress_user_id' => $this->customer_data->user_id,
+        ));
+
         if (!$store_id || !$list_id) {
             mailchimp_debug(get_called_class(), 'StoreID or ListID are not configured');
             return false;
@@ -152,6 +157,12 @@ class MailChimp_Woocommerce_Single_Customer extends Mailchimp_Woocommerce_Job
 
             $current_status = $subscriber['status'];
 
+            mailchimp_debug('customer_submit.trace', 'updated Mailchimp audience member', array(
+                'customer_id' => $this->id,
+                'wordpress_user_id' => $wordpress_user_id,
+                'status' => $current_status,
+            ));
+
             // make sure we set the proper customer status before submitting
             $customer->setOptInStatus(in_array($current_status, array('subscribed', 'pending')));
 
@@ -162,6 +173,13 @@ class MailChimp_Woocommerce_Single_Customer extends Mailchimp_Woocommerce_Job
 
             // update the customer record
             $updated_customer = $api->updateCustomer($store_id, $customer);
+
+            mailchimp_debug('customer_submit.trace', 'completed Mailchimp customer sync', array(
+                'customer_id' => $this->id,
+                'wordpress_user_id' => $wordpress_user_id,
+                'mailchimp_customer_id' => $customer->getId(),
+                'updated_customer' => (bool) $updated_customer,
+            ));
 
             // increment the sync counter
             mailchimp_register_synced_resource('customers');

--- a/includes/processes/class-mailchimp-woocommerce-single-order.php
+++ b/includes/processes/class-mailchimp-woocommerce-single-order.php
@@ -101,6 +101,13 @@ class MailChimp_WooCommerce_Single_Order extends Mailchimp_Woocommerce_Job
 
         $store_id = mailchimp_get_store_id();
 
+        mailchimp_debug('order_submit.trace', 'start', array(
+            'order_id' => $this->id,
+            'is_full_sync' => (bool) $this->is_full_sync,
+            'is_update' => (bool) $this->is_update,
+            'is_admin_save' => (bool) $this->is_admin_save,
+        ));
+
         // this will set the woo_order variable or return false.
         if (!($woo_order_number = $this->getRealOrderNumber())) {
             mailchimp_log('order_submit.failure', "There is no real order number to use for order ID {$this->id}.");
@@ -189,6 +196,17 @@ class MailChimp_WooCommerce_Single_Order extends Mailchimp_Woocommerce_Job
         try {
             // transform the order
             $order = $job->transform($this->woo_order);
+
+            mailchimp_debug('order_submit.trace', 'transformed WooCommerce order', array(
+                'order_id' => $this->id,
+                'order_number' => $woo_order_number,
+                'mailchimp_order_id' => $order->getId(),
+                'line_item_count' => count($order->items()),
+                'financial_status' => $order->getFinancialStatus(),
+                'original_woo_status' => $order->getOriginalWooStatus(),
+                'customer_id' => $this->woo_order->get_user_id(),
+            ));
+
             // all subscriber logic has now been changed
 
             $original_woo_status = $order->getOriginalWooStatus();
@@ -322,6 +340,14 @@ class MailChimp_WooCommerce_Single_Order extends Mailchimp_Woocommerce_Job
             try {
                 // update or create
                 $api_response = $api->$call($store_id, $order, false);
+
+                mailchimp_debug('order_submit.trace', 'completed Mailchimp order sync', array(
+                    'order_id' => $this->id,
+                    'order_number' => $woo_order_number,
+                    'mailchimp_order_id' => $order->getId(),
+                    'method' => $call,
+                    'line_item_count' => count($order->items()),
+                ));
             } catch (Exception $e) {
                 // if for whatever reason we get a product not found error, we need to iterate
                 // through the order items, and use a "create mode only" on each product

--- a/includes/processes/class-mailchimp-woocommerce-single-product-variation.php
+++ b/includes/processes/class-mailchimp-woocommerce-single-product-variation.php
@@ -154,9 +154,24 @@ class MailChimp_WooCommerce_Single_Product_Variation extends Mailchimp_Woocommer
 		$method = "no action";
 
 		try {
+			mailchimp_debug('product_variant_submit.trace', 'start', array(
+				'variation_id' => $this->id,
+				'parent_product_id' => $this->parent_product_id,
+				'mode' => $this->mode,
+				'fallback_title' => !empty($this->fallback_title),
+				'from_order_item' => (bool) $this->order_item,
+			));
+
 			if( !($variant_post = MailChimp_WooCommerce_HPOS::get_product($this->id)) ){
 				return false;
 			}
+
+			mailchimp_debug('product_variant_submit.trace', 'loaded WooCommerce variation', array(
+				'variation_id' => $this->id,
+				'parent_product_id' => $this->parent_product_id,
+				'status' => $variant_post->get_status(),
+				'type' => $variant_post->get_type(),
+			));
 
 			try {
 				// pull the product variation from Mailchimp first to see what method we need to call next.
@@ -187,6 +202,13 @@ class MailChimp_WooCommerce_Single_Product_Variation extends Mailchimp_Woocommer
 
 			$product_variant = $this->transformer()->variant($variant_post, $this->fallback_title);
 
+			mailchimp_debug('product_variant_submit.trace', 'transformed WooCommerce variation', array(
+				'variation_id' => $this->id,
+				'parent_product_id' => $this->parent_product_id,
+				'mailchimp_variant_id' => $product_variant->getId(),
+				'title_present' => (bool) $product_variant->getTitle(),
+			));
+
 			if (empty($product_variant->getTitle()) && !empty($this->fallback_title)) {
 				$product_variant->setTitle($this->fallback_title);
 			}
@@ -200,6 +222,13 @@ class MailChimp_WooCommerce_Single_Product_Variation extends Mailchimp_Woocommer
 
 			// either updating or creating the product
 			$this->api()->{$method}($this->store_id, $product_variant, false);
+
+			mailchimp_debug('product_variant_submit.trace', 'completed Mailchimp variation sync', array(
+				'variation_id' => $this->id,
+				'parent_product_id' => $this->parent_product_id,
+				'mailchimp_variant_id' => $product_variant->getId(),
+				'method' => $method,
+			));
 
 			mailchimp_log('product_variant_submit.success', "{$method} :: #{$product_variant->getId()}");
 

--- a/includes/processes/class-mailchimp-woocommerce-single-product.php
+++ b/includes/processes/class-mailchimp-woocommerce-single-product.php
@@ -132,10 +132,24 @@ class MailChimp_WooCommerce_Single_Product extends Mailchimp_Woocommerce_Job
 
         try {
 
+            mailchimp_debug('product_submit.trace', 'start', array(
+                'product_id' => $this->id,
+                'mode' => $this->mode,
+                'fallback_title' => !empty($this->fallback_title),
+                'from_order_item' => (bool) $this->order_item,
+            ));
+
             if( !($product_post = MailChimp_WooCommerce_HPOS::get_product($this->id)) ){
                 mailchimp_log('product', "tried to load product by ID {$this->id} but did not find it.");
                 return false;
             }
+
+            mailchimp_debug('product_submit.trace', 'loaded WooCommerce product', array(
+                'product_id' => $this->id,
+                'status' => $product_post->get_status(),
+                'type' => $product_post->get_type(),
+                'parent_id' => $product_post->get_parent_id(),
+            ));
 
             // if qe instructed this job to build from the order item, let's do that instead of the product post.
             if ($this->order_item) {
@@ -144,6 +158,12 @@ class MailChimp_WooCommerce_Single_Product extends Mailchimp_Woocommerce_Job
             } else {
                 $product = $this->transformer()->transform($product_post, $this->fallback_title);
             }
+
+            mailchimp_debug('product_submit.trace', 'transformed WooCommerce product', array(
+                'product_id' => $this->id,
+                'mailchimp_product_id' => $product->getId(),
+                'title_present' => (bool) $product->getTitle(),
+            ));
 
             if (empty($product->getTitle()) && !empty($this->fallback_title)) {
                 $product->setTitle($this->fallback_title);
@@ -163,6 +183,12 @@ class MailChimp_WooCommerce_Single_Product extends Mailchimp_Woocommerce_Job
 
             // either updating or creating the product
             $this->api()->updateStoreProduct($this->store_id, $product, false);
+
+            mailchimp_debug('product_submit.trace', 'completed Mailchimp product upsert', array(
+                'product_id' => $this->id,
+                'mailchimp_product_id' => $product->getId(),
+                'method' => $method,
+            ));
 
             mailchimp_log('product_submit.success', "{$method} :: #{$product->getId()}");
             // increment the sync counter


### PR DESCRIPTION
## Summary
- add debug trace logs around product, variation, order, customer, and coupon sync jobs
- add pagination-loop debug traces for sync manager creation, page resource loading, queued page resources, empty responses, and last-page detection
- log start, transformation, and Mailchimp API completion metadata so long-running syncs can be diagnosed from plugin logs
- keep logs behind the existing `mailchimp_debug()` / debug logging path
- avoid logging personal information such as emails, addresses, phone numbers, or names; resource/customer/order IDs are retained for troubleshooting

## Shortcut
- https://app.shortcut.com/vextras/story/50976/add-debug-tracing-for-woocommerce-sync-jobs

## Validation
- `php -l` on changed PHP files
- `git diff --check`
- checked newly-added debug fields for direct PII values

## Context
This should make future “sync has been running forever but Mission Control still shows API traffic” cases clearer by showing whether the plugin reached pagination, WooCommerce object load, transform, and Mailchimp API submission for each resource.
