### PR TITLE
Support custom order types registered via wc_register_order_type

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1334,17 +1334,43 @@ function mailchimp_get_product_categories_count() {
 }
 
 /**
+ * Order post types the plugin should handle. Always returns an array.
+ * Third parties can extend the list via wc_register_order_type + the
+ * 'wc_order_types' filter (with $for === 'mailchimp'), adjust what gets
+ * excluded via the 'mailchimp_order_post_type_exclude_list' filter, or
+ * override the final list via the 'mailchimp_should_push_order_post_type_list'
+ * filter.
+ *
+ * @return array
+ */
+function mailchimp_get_order_post_type_list() {
+    $types = function_exists('wc_get_order_types')
+        ? wc_get_order_types('mailchimp')
+        : array('shop_order');
+
+    // guard against calls made before order types are registered
+    if (empty($types)) {
+        $types = array('shop_order');
+    }
+
+    // refunds are registered as an order type but must never be pushed as orders
+    $excluded = apply_filters('mailchimp_order_post_type_exclude_list', array('shop_order_refund'));
+    $types = array_values(array_diff((array) $types, (array) $excluded));
+
+    $types = (array) apply_filters('mailchimp_should_push_order_post_type_list', $types);
+
+    return array_values(array_unique($types));
+}
+
+/**
  * @return int
  */
 function mailchimp_get_order_count() {
-    return wc_orders_count('completed');
-//    $posts = mailchimp_count_posts('shop_order');
-//    unset($posts['auto-draft'], $posts['trash']);
-//    $total = 0;
-//    foreach ($posts as $status => $count) {
-//        $total += $count;
-//    }
-//    return $total;
+    $total = 0;
+    foreach (mailchimp_get_order_post_type_list() as $type) {
+        $total += (int) wc_orders_count('completed', $type);
+    }
+    return $total;
 }
 
 /**
@@ -1374,7 +1400,7 @@ function mailchimp_get_customer_lookup_count_all() {
  */
 function mailchimp_count_posts($type) {
     global $wpdb;
-    if ($type === 'shop_order') {
+    if (in_array($type, mailchimp_get_order_post_type_list(), true)) {
         $query = "SELECT post_status, COUNT( * ) AS num_posts FROM {$wpdb->posts} WHERE post_type = %s AND post_status = %s";
         $posts = $wpdb->get_results( $wpdb->prepare($query, $type, 'wc-completed'));
     } else {

--- a/includes/api/class-mailchimp-woocommerce-transform-orders-wc3.php
+++ b/includes/api/class-mailchimp-woocommerce-transform-orders-wc3.php
@@ -396,7 +396,7 @@ class MailChimp_WooCommerce_Transform_Orders {
         $limit = $posts + 1;
 
         $params = array(
-			'post_type'      => 'shop_order',
+			'post_type'      => mailchimp_get_order_post_type_list(),
             'post_status'    => 'wc-completed',
 			'posts_per_page' => $limit,
 			'offset'         => $offset,
@@ -436,6 +436,7 @@ class MailChimp_WooCommerce_Transform_Orders {
 		$orders = wc_get_orders(
 			array(
 				'customer' => trim( $order->get_billing_email() ),
+				'type'     => mailchimp_get_order_post_type_list(),
 			)
 		);
 

--- a/includes/class-mailchimp-woocommerce-hpos.php
+++ b/includes/class-mailchimp-woocommerce-hpos.php
@@ -137,7 +137,7 @@ class MailChimp_WooCommerce_HPOS {
 				'numberposts' => 1,
 				'meta_key'    => '_order_number',
 				'meta_value'  => $order_number,
-				'post_type'   => 'shop_order',
+				'post_type'   => mailchimp_get_order_post_type_list(),
 				'post_status' => 'any',
 				'fields'      => 'ids',
 			]);

--- a/includes/class-mailchimp-woocommerce-rest-api.php
+++ b/includes/class-mailchimp-woocommerce-rest-api.php
@@ -838,6 +838,7 @@ class MailChimp_WooCommerce_Rest_Api
                         $platform = $wc_customer;
                         $orders = wc_get_orders( array(
                             'customer' => $body['resource_id'],
+                            'type' => mailchimp_get_order_post_type_list(),
                             'limit' => 1,
                             'orderby' => 'date',
                             'order' => 'DESC',

--- a/includes/class-mailchimp-woocommerce-service.php
+++ b/includes/class-mailchimp-woocommerce-service.php
@@ -563,7 +563,7 @@ class MailChimp_Service extends MailChimp_WooCommerce_Options
     }
 
     /**
-     * Fire new order and order save handling/queueing events when a shop_order post is saved.
+     * Fire new order and order save handling/queueing events when an order of a supported type is saved.
      *
      * @param $order_id
      * @param $order

--- a/includes/processes/class-mailchimp-woocommerce-single-order.php
+++ b/includes/processes/class-mailchimp-woocommerce-single-order.php
@@ -107,9 +107,7 @@ class MailChimp_WooCommerce_Single_Order extends Mailchimp_Woocommerce_Job
             return false;
         }
 
-        $order_post_type_list = apply_filters( 'mailchimp_should_push_order_post_type_list', [
-            'shop_order'
-        ]);
+        $order_post_type_list = mailchimp_get_order_post_type_list();
 
         if ( ! in_array( $this->woo_order->get_type(), $order_post_type_list ) ) {
             mailchimp_log('filter', "Order {$woo_order_number} was skipped by the filter");


### PR DESCRIPTION
## Problem

Custom order types registered via `wc_register_order_type` (for example a `club_order` type used alongside `shop_order`) are inconsistently supported across the plugin's order sync paths. The `mailchimp_should_push_order_post_type_list` filter exists in a single place (the single order push gate), while the initial full sync query, order counts and order number lookups use a hardcoded `shop_order`. As a result, custom type orders can pass the push filter but never enter the full sync and are missing from counts.

## Solution

A new helper centralizes the list of supported order post types and always returns an array:

```php
function mailchimp_get_order_post_type_list() {
    $types = function_exists('wc_get_order_types')
        ? wc_get_order_types('mailchimp')
        : array('shop_order');
    ...
    return array_values(array_unique($types));
}
```

Key decisions:

- The default comes from `wc_get_order_types('mailchimp')`. Since `mailchimp` is not a core context, WooCommerce returns all registered order types and passes the context to the `wc_order_types` filter, so types registered via `wc_register_order_type` are picked up automatically and developers can fine tune the list per context.
- `shop_order_refund` is excluded by default through a dedicated `mailchimp_order_post_type_exclude_list` filter, not a fixed exclusion. Refunds are registered as an order type and stored with `wc-completed` status, so without the exclusion the full sync query would pull refund records and the order transformer would reject them. Exposing the exclusion as a filter lets developers include refunds or exclude other types without touching the plugin, since WooCommerce's own `wc_order_types` filter cannot carry a custom flag through: `wc_register_order_type()` strips any unknown arg key before storing it, and `wc_get_order_types()` only returns type slugs to that filter, not the original registration args.
- The existing `mailchimp_should_push_order_post_type_list` filter is applied on top of the new default, keeping backward compatibility for sites already using it.
- The result is deduplicated and falls back to `array('shop_order')` when order types are not registered yet.

## Changes

- `bootstrap.php`: new `mailchimp_get_order_post_type_list()` helper; `mailchimp_get_order_count()` now sums `wc_orders_count('completed', $type)` per supported type; `mailchimp_count_posts()` resolves the completed status branch against the type list instead of `$type === 'shop_order'`.
- `includes/processes/class-mailchimp-woocommerce-single-order.php`: the type gate uses the shared helper instead of applying the filter with a hardcoded `shop_order` default.
- `includes/api/class-mailchimp-woocommerce-transform-orders-wc3.php`: `getOrderPosts()` (full sync) queries all supported types. This works on both storage modes: `get_posts` accepts an array in `post_type` and `wc_get_orders` maps the legacy `post_type` argument to `type`, which also accepts an array. `getCustomerOrderTotals()` passes the type list explicitly.
- `includes/class-mailchimp-woocommerce-hpos.php`: `get_post_id_from_order_number()` (non HPOS fallback) accepts all supported types.
- `includes/class-mailchimp-woocommerce-rest-api.php`: the customer lookup by latest order passes the type list explicitly, since `WC_Order_Query` does not include custom types by default.
- `includes/class-mailchimp-woocommerce-service.php`: docblock update only; the type gate stays in the single order job, so `woocommerce_new_order` and `woocommerce_update_order` events from custom types flow naturally.

----

Fixes #1402 
_Created with Claude Code because I'm not able to get a dev environment right now but every line was reviewed and I rechecked all WordPress / WooCommerce docs._